### PR TITLE
update benchmark to remove spammer question

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ const remoteSrc = require('gulp-remote-src');
 const replace = require('gulp-replace');
 const uglify = require('gulp-uglify');
 
-const BENCHMARKJS_VERSION = '2.1.0';
+const BENCHMARKJS_VERSION = require('./package.json').devDependencies.benchmark;
 const requestOptions = {
 	'gzip': true,
 	'strictSSL': true

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": "https://github.com/jsperf/benchmark.js-wrapper/issues",
   "devDependencies": {
     "@alrra/travis-scripts": "^3.0.1",
-    "benchmark": "2.1.0",
+    "benchmark": "2.1.1",
     "gulp": "^3.9.0",
     "gulp-add-src": "^0.2.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
v1.0.2 didn't update benchmark version so didn't pull in [removal of spammer question](https://github.com/bestiejs/benchmark.js/compare/2.1.0...2.1.1#diff-81cd1eec109c1a627eeb236617e5cc97L230). should fix jsperf/jsperf.com#152
